### PR TITLE
Remove unnecessary scrollbars from table

### DIFF
--- a/app.py
+++ b/app.py
@@ -1057,9 +1057,8 @@ h_table = dash_table.DataTable(
     #filter_query='{Bundesland} = Berlin',
     page_size= 500,
     style_table = {
-            'minWidth': tableWidth, 'width': tableWidth, 'maxWidth': tableWidth,
+            'minWidth': tableWidth,
             'minHeight': tableHeight, 'height': tableHeight, 'maxHeight': tableHeight,
-            'overflow-y': 'scroll',
 #            'tableLayout': 'auto'
             'table-layout': 'fixed'
     },


### PR DESCRIPTION
When using the developer tools to remove the `width`, `max-width` and `overflow-y` from the `.dash-spreadsheet-container.dash-spreadsheet` element it removed the unnecessary horizontal scrollbar as well as the duplicated vertical scrollbar on the right of the table. These doesn't scroll anything for me, but sometimes caused the table body and header to misalign. Worked for me in Chrome and Firefox on Desktop and didn't find any issues caused by this modification.

Haven't tested other browsers or mobile, though and only guessed that this is the right place in the code to fix this, as I haven't executed it myself and only tried the fix using the Browser Development tools.