### PR TITLE
Dokumentation und update.sh konfigurierbar

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -1,0 +1,16 @@
+# Corona
+Code für Prozessierung der Corona-Daten in Deutschland.
+
+## How to
+Die notwendigen Schritte um die Inputdaten herunterzuladen und die Ergebnisse zu produzieren können mit dem Skript `update.sh` ausgeführt werden: `source update.sh`. Die Standardeinstellungen entsprechen dem Setup von Pavel, können aber mit Hilfe von zwei Umgebungsvariablen angepasst werden (mit z.B. `export CORONA=/Pfad/zum/Arbeitsordner`):
+* `CORONA`: Hauptordner dieses Repositories
+* `GOOGLE_SDK_PATH`: Pfad zu `google-cloud-sdk`. Das wird genutzt um die Inputdaten herunterzuladen.
+
+## Voraussetzungen
+
+* `google-cloud-sdk`
+* `python 3.6+`?
+    * [datatable](https://github.com/h2oai/datatable)
+    * ndjson
+    * pytz
+* (aktuell unvollständig)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Corona
+Code for German Corona-Data processing.
+
+Other languages: [Deutsch](README-de.md)
+
+## How to
+The necessary steps to download the input data and to produce the results can be performed using the `update.sh` script (execute via `source update.sh`). The default settings of this script match pavel's setup, but this can be customized via two environment variables (e.g. with `export CORONA=/path/to/my/corona/directory):
+* `CORONA`: root directory of this repository
+* `GOOGLE_SDK_PATH`: path to google-cloud-sdk, this is used to download the input files
+
+## Requirements
+
+* `google-cloud-sdk`
+* `python 3.x`?
+    * [datatable](https://github.com/h2oai/datatable)
+    * ndjson
+    * pytz
+* (to be completed)

--- a/update.sh
+++ b/update.sh
@@ -1,17 +1,36 @@
 #/bin/bash
-CORONA=/Users/pavel/Corona
+
+# user specific settings
+# (defaults match pavel's settings, but can be overriden)
+if [ -z "$CORONA" ]
+then
+    CORONA=$HOME/Corona
+fi
+if [ -z "$GOOGLE_SDK_PATH" ]
+then
+    GOOGLE_SDK_PATH=/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk
+fi
+
+SHELLNAME=$(basename `echo $SHELL`)
+
+# prepare environment
 #cd $CORONA/2020-rki-archive
 #git pull
 cd $CORONA
 
-mkdir -p ard-data
 mkdir -p ard-data
 mkdir -p archive_ard
 mkdir -p archive_v2
 mkdir -p series
 mkdir -p series-enhanced
 
-source /usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/path.bash.inc
+if [ -e $GOOGLE_SDK_PATH ]
+then
+    source $GOOGLE_SDK_PATH/path.$SHELLNAME.inc
+else
+    echo "Could not find Google Cloud sdk path at: $GOOGLE_SDK_PATH"
+fi
+
 gsutil rsync -d -r gs://brdata-public-data/rki-corona-archiv/ ard-data
 
 cd $CORONA/ard-data/2_parsed


### PR DESCRIPTION
* Fügt Anfänge einer Dokumentation hinzu
* Skript `update.sh` ist nun durch Nutzer anpassbar. Defaults entsprechen Einstellungen von Pavel, aber dies kann nun überschrieben werden (siehe Dokumentation)